### PR TITLE
Fix POI section header being transparent

### DIFF
--- a/qml/POIs.qml
+++ b/qml/POIs.qml
@@ -74,11 +74,17 @@ Item {
         section.property: "theme"
         section.criteria: ViewSection.FullString
         section.labelPositioning: ViewSection.CurrentLabelAtStart + ViewSection.InlineLabels
-        section.delegate: ListItemHeader {
+        section.delegate: Rectangle {
             width: parent.width
             height: sectionHeader.height
-            id: sectionHeader
-            title: section
+            color: theme.palette.normal.background
+
+            ListItemHeader {
+                width: parent.width
+                height: sectionHeader.height
+                id: sectionHeader
+                title: section
+            }
         }
 
         delegate: ListItem {


### PR DESCRIPTION
^____^ sorry

In POI, if you scroll, section header is transparent (I took out the Rectangle in a previous MR, sorry).
This should fix that in Ambiance and SuruDark